### PR TITLE
Add Trident Support

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSEntityListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSEntityListener.java
@@ -620,6 +620,12 @@ public class PSEntityListener implements Listener {
                     if (arrow.getShooter() instanceof Player) {
                         attacker = (Player) arrow.getShooter();
                     }
+                } else if (sub.getDamager() instanceof Trident) {
+                	Trident trident = (Trident) sub.getDamager();
+
+                    if (trident.getShooter() instanceof Player) {
+                        attacker = (Player) trident.getShooter();
+                    }
                 }
 
                 if (attacker != null) {


### PR DESCRIPTION
Fixed an issue in which players could damage with a trident in pvp protected zones. (This fix doesnt return the trident to its owner if he doesnt have loyalty though, it just cancels the damage, but it works as arrows, you can go and pick it)

Not sure if you need to change some more stuff for 1.15.2 support but I doubt (also remember to update the plugin version number)

And I have a question: do you know how WorldEdit support works? Because in my server some players have access to WorldEdit, and they are able to destroy protected regions with it. Can that be protected or it is not possible?

Thanks!