### PR TITLE
Projectiles will be analized in EntityDamageByEntityEvent

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSEntityListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSEntityListener.java
@@ -614,17 +614,11 @@ public class PSEntityListener implements Listener {
 
                 if (sub.getDamager() instanceof Player) {
                     attacker = (Player) sub.getDamager();
-                } else if (sub.getDamager() instanceof Arrow) {
-                    Arrow arrow = (Arrow) sub.getDamager();
+                } else if (sub.getDamager() instanceof Projectile) {
+                    Projectile projectile = (Projectile) sub.getDamager();
 
-                    if (arrow.getShooter() instanceof Player) {
-                        attacker = (Player) arrow.getShooter();
-                    }
-                } else if (sub.getDamager() instanceof Trident) {
-                	Trident trident = (Trident) sub.getDamager();
-
-                    if (trident.getShooter() instanceof Player) {
-                        attacker = (Player) trident.getShooter();
+                    if (projectile.getShooter() instanceof Player) {
+                        attacker = (Player) projectile.getShooter();
                     }
                 }
 


### PR DESCRIPTION
Now the plugin will be future proof to any new type of projectile added in the game. Now players wont be damaged if they are being hit by any projectile shot by another player. This replaces the Arrow and Trident check as both extend from Projectile class. This also considers InstantDamage potions but not other types as EntityDamageByEntityEvent is not being called (though there is another system for preventint potion damage so wont be a problem)